### PR TITLE
Use BigDecimal() instead of BigDecimal.new

### DIFF
--- a/lib/payday/invoice.rb
+++ b/lib/payday/invoice.rb
@@ -33,12 +33,12 @@ module Payday
 
     # The tax rate that we're applying, as a BigDecimal
     def tax_rate=(value)
-      @tax_rate = BigDecimal.new(value.to_s)
+      @tax_rate = BigDecimal(value.to_s)
     end
 
     # Shipping rate
     def shipping_rate=(value)
-      @shipping_rate = BigDecimal.new(value.to_s)
+      @shipping_rate = BigDecimal(value.to_s)
     end
   end
 end

--- a/lib/payday/invoiceable.rb
+++ b/lib/payday/invoiceable.rb
@@ -20,7 +20,7 @@ module Payday::Invoiceable
 
   # Calculates the subtotal of this invoice by adding up all of the line items
   def subtotal
-    line_items.reduce(BigDecimal.new("0")) { |result, item| result += item.amount }
+    line_items.reduce(BigDecimal("0")) { |result, item| result += item.amount }
   end
 
   # The tax for this invoice, as a BigDecimal

--- a/lib/payday/line_item.rb
+++ b/lib/payday/line_item.rb
@@ -20,12 +20,12 @@ module Payday
 
     # Sets the quantity of this {LineItem}
     def quantity=(value)
-      @quantity = BigDecimal.new(value.to_s)
+      @quantity = BigDecimal(value.to_s)
     end
 
     # Sets the price for this {LineItem}
     def price=(value)
-      @price = BigDecimal.new(value.to_s)
+      @price = BigDecimal(value.to_s)
     end
   end
 end

--- a/lib/payday/pdf_renderer.rb
+++ b/lib/payday/pdf_renderer.rb
@@ -222,7 +222,7 @@ module Payday
       invoice.line_items.each do |line|
         table_data << [line.description,
                        (line.display_price || number_to_currency(line.price, invoice)),
-                       (line.display_quantity || BigDecimal.new(line.quantity.to_s).to_s("F")),
+                       (line.display_quantity || BigDecimal(line.quantity.to_s).to_s("F")),
                        number_to_currency(line.amount, invoice)]
       end
 

--- a/lib/payday/version.rb
+++ b/lib/payday/version.rb
@@ -1,5 +1,5 @@
 # This is Payday!
 module Payday
   # Current Version
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
There are lots of warnings in Rails' logs:
`warning: BigDecimal.new is deprecated; use BigDecimal() method instead.`